### PR TITLE
plugin: hexo-shokax-hitokoto

### DIFF
--- a/extensions/hitokoto/README.md
+++ b/extensions/hitokoto/README.md
@@ -1,0 +1,14 @@
+[hexo-theme-shokaX](https://github.com/zkz098/hexo-theme-shokaX) 主题插件，用于向页脚插入 hitikoto 一言功能
+
+## 使用
+js 安装，或者用 pnpm：`pnpm add hexo-shokax-hitokoto`
+
+向主题文件夹中的 `_config.yml` 中插入：`hitokoto: true`
+
+控制是否显示一言
+
+![image-20250121145614843](https://res.cloudinary.com/sycamore/image/upload/v1737442577/Typora/2025/01/c89e9781614444ee17835b8a0f5c1393.png)
+
+![image-20250121145635232](https://res.cloudinary.com/sycamore/image/upload/v1737442597/Typora/2025/01/77c7e646be79dd11c6c0a1f31352917e.png)
+
+![image-20250121145657663](https://res.cloudinary.com/sycamore/image/upload/v1737442620/Typora/2025/01/a86a7b475ed20900a39bea3bfdb0e4f6.png)

--- a/extensions/hitokoto/hitokoto.js
+++ b/extensions/hitokoto/hitokoto.js
@@ -1,0 +1,5 @@
+const path = require('path');
+
+hexo.extend.filter.register('theme_inject', function(injects) {
+    injects.footer.file('hitokoto', path.join(__dirname, 'views/hitokoto.pug'),{}, {cache: false});
+});

--- a/extensions/hitokoto/views/hitokoto.pug
+++ b/extensions/hitokoto/views/hitokoto.pug
@@ -1,0 +1,17 @@
+if theme.hitokoto
+    div(style="width: 100%;text-align:center;")
+        span(id="sentences-content", style="color: #ebb563;")
+            != '一言...'
+    div(style="width: 100%;text-align:center;")
+        span(id="sentences-from")
+            != '來源'
+        script(type="text/javascript").
+            fetch(`https://v1.hitokoto.cn/`)
+            .then(response => response.json())
+            .then(data => {
+                var content = document.getElementById('sentences-content');
+                content.innerText = data.hitokoto
+                var from = document.getElementById('sentences-from');
+                from.innerText = data.from + (data.from_who && data.from_who != data.from ? ' · ' + data.from_who : '')
+            })
+            .catch(console.error)


### PR DESCRIPTION
# 新增插件：一言页脚

向页脚插入 hitikoto 一言功能

## 使用
js 安装，或者用 pnpm：`pnpm add hexo-shokax-hitokoto`

向主题文件夹中的 `_config.yml` 中插入：`hitokoto: true`

控制是否显示一言

![image-20250121145614843](https://res.cloudinary.com/sycamore/image/upload/v1737442577/Typora/2025/01/c89e9781614444ee17835b8a0f5c1393.png)

![image-20250121145635232](https://res.cloudinary.com/sycamore/image/upload/v1737442597/Typora/2025/01/77c7e646be79dd11c6c0a1f31352917e.png)

![image-20250121145657663](https://res.cloudinary.com/sycamore/image/upload/v1737442620/Typora/2025/01/a86a7b475ed20900a39bea3bfdb0e4f6.png)